### PR TITLE
Update README.md: Reflect the state of WebP support

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,9 +100,9 @@ Setup: Edit > Preferences > AI. Point it at your `onnxruntime.dll` / `libonnxrun
 
 ## File Formats
 
-**Read:** PNG, JPEG, WebP, BMP, TIFF, TGA, GIF (animated), APNG (animated), `.PFE`, CR2/CR3/NEF/ARW/DNG/ORF/RW2/SRW/PEF/RAF (RAW via `rawloader`)
+**Read:** PNG, JPEG, WebP (lossy and lossles, static only), BMP, TIFF, TGA, GIF (animated), APNG (animated), PaintFE project (`.PFE`), CR2/CR3/NEF/ARW/DNG/ORF/RW2/SRW/PEF/RAF (RAW via `rawloader`)
 
-**Write:** PNG, JPEG, WebP, BMP, TIFF, TGA, ICO, GIF (static + animated), APNG (animated), `.PFE`
+**Write:** PNG, JPEG, WebP (static lossy only), BMP, TIFF, TGA, ICO, GIF (static + animated), APNG (animated), PaintFE project (`.PFE`)
 
 Animated export: each visible layer = one frame. FPS, loop count, and GIF palette are configurable in the export dialog.
 


### PR DESCRIPTION
Hello 😉

I'd like to start by thanking you for the good job on PaintFE. I'm looking forward to replacing Paint.net with PaintFE.

As soon as I read that PaintFE supports WebP, I asked myself "What kind of WebP"?

That's an important question because WebP supports both lossy and lossless compression, with different codecs for each. Like APNG and GIF, WebP also supports animation, each frame of which could use either lossy or lossless compression. I'm particularly fond of the lossless WebP because it consistently yields smaller sizes than PNG and is supported by most web browsers and most websites (including GitHub).

My tests shows that PaintFE v1.2.17 can read lossy and lossless WebP images but can only write the lossy kind. Also, it doesn't support animation. In this PR, I propose updating `README.md` to reflect that fact.

<img width="100" height="100" alt="Animated_PNG_example_bouncing_beach_ball" src="https://github.com/user-attachments/assets/a1ab40d9-ca93-4fb9-b4eb-f5b4cdf23f27" />