### PR TITLE
fix: resolve ARM build error in linux_key_probe

### DIFF
--- a/src/linux_key_probe.rs
+++ b/src/linux_key_probe.rs
@@ -106,7 +106,7 @@ mod imp {
         // SAFETY: display is valid for the lifetime of the probe state, and
         // keys points to a writable 32-byte buffer as required by XQueryKeymap.
         unsafe {
-            (state.xlib.XQueryKeymap)(state.display, keys.as_mut_ptr());
+            (state.xlib.XQueryKeymap)(state.display, keys.as_mut_ptr() as *mut _);
         }
 
         let ctrl_down = key_down(&keys, state.ctrl_l) || key_down(&keys, state.ctrl_r);


### PR DESCRIPTION
When building PaintFE on an ARM device (e.g., MediaTek Chromebook / aarch64), the build fails with `expected *mut u8, found *mut i8` at `linux_key_probe.rs`.

This PR adds an `as *mut _` cast to `keys.as_mut_ptr()` when calling `XQueryKeymap`. This safely resolves the character type mismatch between x86 (where `char` is signed) and ARM (where `char` is unsigned), allowing the project to compile successfully on ARM architectures.